### PR TITLE
Add basic Purchase model and endpoints

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -29,11 +29,13 @@ def create_app(conf='conf.local.Config'):
     from server.routes.articles import ARTICLES_BP
     from server.routes.accounts import ACCOUNTS_BP
     from server.routes.chat_messages import CHAT_MESSAGES_BP
+    from server.routes.purchases import PURCHASES_BP
     app.register_blueprint(EXAMPLE_BP)
     app.register_blueprint(PING_BP)
     app.register_blueprint(ARTICLES_BP)
     app.register_blueprint(ACCOUNTS_BP)
     app.register_blueprint(CHAT_MESSAGES_BP)
+    app.register_blueprint(PURCHASES_BP)
 
     # use the modified encoder class to handle ObjectId and Datetime object
     # while jsonifying the response

--- a/server/model/account.py
+++ b/server/model/account.py
@@ -15,5 +15,5 @@ class Account(Model):
     }
 
     @classmethod
-    def current(cls):
+    def current(cls) -> 'Account':
         return cls.get_many(user_id=user_id())[0]

--- a/server/model/base.py
+++ b/server/model/base.py
@@ -109,7 +109,7 @@ class Model:
 
     def to_json(self):
         data = self._data.copy()
-        data.update({'_id': self._id})
+        data.update({'_id': self.get_id()})
         return data
 
     def save(self):

--- a/server/model/purchase.py
+++ b/server/model/purchase.py
@@ -1,0 +1,26 @@
+from server.model.account import Account
+from server.model.article import Article
+from server.model.base import Model
+
+
+class Purchase(Model):
+    db_name = 'purchases'
+
+    schema = {
+        'user_id': str,
+        'article_id': str,
+        'units': int,
+    }
+
+    @classmethod
+    def get_for_user(cls, user: Account):
+        user_id = user.get_id()
+        purchases = cls.get_many(user_id=user_id)
+        result = []
+        for purchase in purchases:
+            purchase = purchase.to_json()
+            purchase['article'] = Article.get_one(  # N database calls, i know
+                str(purchase.pop('article_id'))
+            ).to_json()
+            result.append(purchase)
+        return result

--- a/server/routes/purchases.py
+++ b/server/routes/purchases.py
@@ -25,7 +25,7 @@ def buy():
     try:
         article = Article.get_one(article_id)
         if article is None:
-            response("article ID {article_id} not found", ok=False), 400
+            return response("article ID {article_id} not found", ok=False), 400
     except ValueError:
         return response(f"article_id not specified", ok=False), 400
 

--- a/server/routes/purchases.py
+++ b/server/routes/purchases.py
@@ -1,0 +1,34 @@
+from flask import Blueprint, request, jsonify
+
+from server.decorators.login_required import login_required
+from server.model.account import Account
+from server.model.article import Article
+from server.model.purchase import Purchase
+from server.utils import response, create
+
+PURCHASES_BP = Blueprint('purchases', __name__, url_prefix='/purchase')
+
+
+@PURCHASES_BP.route('/', methods=['GET'])
+@login_required
+def get_purchases():
+    user = Account.current()
+    return jsonify({'data': Purchase.get_for_user(user), 'ok': True}), 200
+
+
+@PURCHASES_BP.route('/', methods=['POST'])
+@login_required
+def buy():
+    body = request.json
+    article_id = body.get('article_id')
+
+    try:
+        article = Article.get_one(article_id)
+        if article is None:
+            response("article ID {article_id} not found", ok=False), 400
+    except ValueError:
+        return response(f"article_id not specified", ok=False), 400
+
+    account_id = Account.current().get_id()
+    body['user_id'] = account_id
+    return create(Purchase, additional_fields={'user_id': account_id})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
 import pytest
+from faker import Faker
 from server.libs.mongo import mongo
 
 from server.app import create_app
+from server.model.article import Article
+
+fake = Faker()
 
 
 @pytest.fixture
@@ -12,5 +16,21 @@ def client():
 
     # Clear databases
     mongo.db['articles'].delete_many({})
+    mongo.db['purchases'].delete_many({})
     yield client
 
+
+@pytest.fixture
+def article():
+    art = Article({
+        "name": fake.pystr(),
+        "description": fake.text(),
+        "available_units": fake.pyint(),
+        "price": fake.pyfloat(),
+        "latitude": fake.pyfloat(),
+        "longitude": fake.pyfloat(),
+        "user": fake.pystr(),
+    })
+    art.save()
+    yield art
+    art.delete()

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -1,0 +1,31 @@
+import json
+
+
+def test_get_user_purchases(client):
+    resp = client.get('/purchase/')
+    assert resp.status_code == 200
+    assert not resp.json['data']
+
+
+def test_post_purchase(client, article):
+    resp = client.post('/purchase/', data=json.dumps({
+        "article_id": article.get_id(),
+        "units": article['available_units']
+    }), content_type='application/json')
+
+    assert resp.status_code == 200
+
+    resp = client.get('/purchase/')
+    assert resp.status_code == 200
+    article = article.to_json()
+    resp_article = resp.json['data'][0]['article']
+    for key in article:
+        assert resp_article[key] == article[key]
+
+
+def test_post_bad_article(client):
+    resp = client.post('/purchase/', data=json.dumps({
+        "units": 1,
+    }), content_type='application/json')
+
+    assert resp.status_code == 400


### PR DESCRIPTION
Closes #29 

Purchase model with:
  - user id (from Firebase)
  - article id (from mongo)
  - units bought

Basic endpoints to get an user's purchases, and create a new one. On
list, the whole Article model is returned, not only its id.